### PR TITLE
chore(devops): require PRs to link an issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Select one (aligns with `commitlint.config.cjs` scopes):
 - [ ] permission
 - [ ] i18n
 - [ ] theme
+- [ ] devops
 
 ## Screenshots / Recording (if UI changes)
 - Before:
@@ -38,5 +39,5 @@ Select one (aligns with `commitlint.config.cjs` scopes):
 - [ ] No secrets or credentials are included
 
 ## Related
-- Issue / ticket:
+- Fixes #<issue-number>
 - Follow-ups:

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,32 @@
+name: Require linked issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  require-linked-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Ensure PR links an issue (Fixes/Closes/Resolves)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr?.title ?? "";
+            const body = pr?.body ?? "";
+            const text = `${title}\n${body}`.trim();
+
+            // Accept e.g.:
+            // - Fixes #123
+            // - Closes owner/repo#123
+            // - Resolves #123
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+\b/i;
+
+            if (!re.test(text)) {
+              core.setFailed(
+                "PR description must include an issue-closing keyword, e.g. `Fixes #123` (or `Closes #123` / `Resolves #123`)."
+              );
+            }

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ We use **Conventional Commits** and enforce rules via **commitlint**.
 Based on the current git diff, generate a commit message that follows these rules:
 
 - Format: type(scope): description
-- Type must be one of: feat, fix, refactor, perf, style, test, docs, chore, build
-- Scope must be one of: ui, layout, page, component, hook, api, state, router, auth, permission, i18n, theme
+- Type must be one of: feat, fix, refactor, perf, style, test, docs, chore, build, ci
+- Scope must be one of: ui, layout, page, component, hook, api, state, router, auth, permission, i18n, theme, devops
 - Description must start with a verb; keep it short and clear
 - Output only a single-line commit message (no code block, no quotes, no extra text)
 ```

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
     'type-enum': [
       2,
       'always',
-      ['feat', 'fix', 'refactor', 'perf', 'style', 'test', 'docs', 'chore', 'build'],
+      ['feat', 'fix', 'refactor', 'perf', 'style', 'test', 'docs', 'chore', 'build', 'ci'],
     ],
     'scope-enum': [
       2,


### PR DESCRIPTION
Fixes #3

## Summary
- Add a GitHub Actions check enforcing issue links in PR text. Align commitlint types and update docs/templates.

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [x] devops