### PR TITLE
ci: add branch name check and commitlint workflows

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,40 @@
+name: Branch name check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  branch-name-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+          echo "Branch: ${BRANCH_NAME}"
+
+          # Allowed:
+          # - feature/*, bugfix/*, hotfix/*, release/*, chore/*, docs/*, refactor/*, test/*
+          # - dependabot/*, renovate/*
+          # - main, master, develop
+          #
+          # Examples:
+          # - feature/add-login
+          # - bugfix/fix-null-pointer
+          # - chore/update-deps
+          #
+          # Pattern uses lowercase letters/digits separated by - or /.
+          PATTERN='^(main|master|develop|dependabot\/.+|renovate\/.+|(feature|bugfix|hotfix|release|chore|docs|refactor|test)\/[a-z0-9]+([-/][a-z0-9]+)*)$'
+
+          if [[ -z "${BRANCH_NAME}" ]]; then
+            echo "Unable to determine branch name."
+            exit 1
+          fi
+
+          if [[ ! "${BRANCH_NAME}" =~ ${PATTERN} ]]; then
+            echo "Invalid branch name: ${BRANCH_NAME}"
+            echo "Branch name must match: ${PATTERN}"
+            exit 1
+          fi

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,21 @@
+name: Commitlint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.cjs


### PR DESCRIPTION
Resolves #4 

## Summary
Add CI workflows to enforce branch naming conventions and commit message linting. This ensures that all branches and commits follow a consistent standard.

- What problem does this PR solve?
  - Previously, there was no automated check for branch names or commit messages. 
- What approach did you take?
  - Implement a GitHub Actions workflow to validate branch names on pull requests.

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout 
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [x] devops
