### PR TITLE
chore(devops): fix eslint tsconfig root resolution in monorepo

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,17 +1,29 @@
 import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ['dist/**', 'node_modules/**', 'prisma/migrations/**'],
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ['**/*.ts'],
+    files: ['src/**/*.ts'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,13 @@ export default tseslint.config(
       'apps/web/public/example/**',
     ],
   },
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   // apps/web (React)
@@ -34,11 +41,15 @@ export default tseslint.config(
   },
   // apps/api (Node)
   {
-    files: ['apps/api/**/*.ts'],
+    files: ['apps/api/src/**/*.ts'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
       globals: { ...globals.node },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],


### PR DESCRIPTION
## Summary
- Fix ESLint parser ambiguity between repo root and `apps/api`.
- Add explicit `tsconfigRootDir` handling for root/API ESLint configs.
- Keep API type-aware linting (`projectService`) scoped to `apps/api/src/**/*.ts`.

## Test plan
- [x] npm run lint --workspace=@salesops/api
- [x] npm run lint
- [x] npm run build

## Related
- Fixes #18

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [x] devops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced linting configuration to improve TypeScript support and code quality verification. Updated settings to enable more accurate and consistent code analysis across projects and development environments. These changes provide better IDE integration for enhanced real-time feedback during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->