### PR TITLE
feat(page): add Products table alignment and sort

### DIFF
--- a/apps/web/src/layout/DefaultLayout.tsx
+++ b/apps/web/src/layout/DefaultLayout.tsx
@@ -21,9 +21,11 @@ export function DefaultLayout() {
           {/* <!-- ===== Header End ===== --> */}
 
           {/* <!-- ===== Main Content Start ===== --> */}
-          <main>
-            <div className="mx-auto max-w-screen-2xl p-4 md:p-6">
-              <Outlet />
+          <main className="flex-1 min-h-0">
+            <div className="mx-auto flex h-full min-h-0 flex-col p-4 md:p-6">
+              <div className="flex min-h-0 flex-1 flex-col">
+                <Outlet />
+              </div>
             </div>
           </main>
           {/* <!-- ===== Main Content End ===== --> */}

--- a/apps/web/src/views/Products/index.tsx
+++ b/apps/web/src/views/Products/index.tsx
@@ -1,3 +1,4 @@
+import type { SorterResult } from 'antd/es/table/interface';
 import { useMemo, useState } from 'react';
 import type { SKU, ProductStatus } from '@salesops/shared';
 import type { StatusFilter, ProductRow } from './types';
@@ -31,6 +32,8 @@ export function ProductsPage() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_TABLE_PAGE_SIZE);
   const [expandedRowKeys, setExpandedRowKeys] = useState<readonly number[]>([]);
+  const [sortField, setSortField] = useState<string | undefined>();
+  const [sortOrder, setSortOrder] = useState<'ascend' | 'descend' | undefined>();
 
   const filteredProducts = useMemo(() => {
     return productMocks.filter((product) => {
@@ -40,34 +43,66 @@ export function ProductsPage() {
     });
   }, [search, statusFilter]);
 
-  const totalPages = Math.max(1, Math.ceil(filteredProducts.length / pageSize));
-  const safePage = Math.min(page, totalPages);
-  const pageNumbers = Array.from({ length: totalPages }, (_, index) => index + 1);
-  const paginatedProducts = filteredProducts
-    .slice((safePage - 1) * pageSize, safePage * pageSize)
-    .map((product): ProductRow => {
+  const sortedProducts = useMemo(() => {
+    const products = filteredProducts.map((product): ProductRow => {
       const prices = product.skus.map((sku) => sku.price);
       const minPrice = prices.length > 0 ? Math.min(...prices) : 0;
       const maxPrice = prices.length > 0 ? Math.max(...prices) : 0;
       const totalStock = product.skus.reduce((sum, sku) => sum + sku.stock, 0);
-
-      return {
-        ...product,
-        key: product.id,
-        minPrice,
-        maxPrice,
-        totalStock,
-      };
+      return { ...product, key: product.id, minPrice, maxPrice, totalStock };
     });
+    if (!sortField || !sortOrder) return products;
+    return [...products].sort((a, b) => {
+      let comparison = 0;
+      switch (sortField) {
+        case 'name':
+          comparison = a.name.localeCompare(b.name);
+          break;
+        case 'status':
+          comparison = (a.status ?? '').localeCompare(b.status ?? '');
+          break;
+        case 'skuCount':
+          comparison = a.skus.length - b.skus.length;
+          break;
+        case 'totalStock':
+          comparison = a.totalStock - b.totalStock;
+          break;
+        case 'minPrice':
+          comparison = a.minPrice - b.minPrice;
+          break;
+        default:
+          return 0;
+      }
+      return sortOrder === 'ascend' ? comparison : -comparison;
+    });
+  }, [filteredProducts, sortField, sortOrder]);
 
-  const showingFrom = filteredProducts.length === 0 ? 0 : (safePage - 1) * pageSize + 1;
-  const showingTo = Math.min(safePage * pageSize, filteredProducts.length);
+  const totalPages = Math.max(1, Math.ceil(sortedProducts.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageNumbers = Array.from({ length: totalPages }, (_, index) => index + 1);
+  const paginatedProducts = sortedProducts
+    .slice((safePage - 1) * pageSize, safePage * pageSize);
 
-  const columns: TableColumnsType<ProductRow> = [
+  const showingFrom = sortedProducts.length === 0 ? 0 : (safePage - 1) * pageSize + 1;
+  const showingTo = Math.min(safePage * pageSize, sortedProducts.length);
+
+  const handleTableChange = (_pagination: unknown, _filters: unknown, sorter: SorterResult<ProductRow> | SorterResult<ProductRow>[]) => {
+    const result = Array.isArray(sorter) ? sorter[0] : sorter;
+    setSortField(result.columnKey as string | undefined);
+    setSortOrder(result.order === null ? undefined : result.order);
+    setPage(1);
+  };
+
+  const columns: TableColumnsType<ProductRow> = useMemo(
+    () => [
     {
       title: renderHeaderTitle('Product'),
       dataIndex: 'name',
       key: 'name',
+      width: 200,
+      sorter: true,
+      sortOrder: sortField === 'name' ? sortOrder : undefined,
+      showSorterTooltip: false,
       render: (name: string) => (
         <span className="font-normal text-gray-800 dark:text-white/90">{name}</span>
       ),
@@ -77,6 +112,9 @@ export function ProductsPage() {
       dataIndex: 'status',
       key: 'status',
       width: 150,
+      sorter: true,
+      sortOrder: sortField === 'status' ? sortOrder : undefined,
+      showSorterTooltip: false,
       render: (status: ProductStatus) => (
         <Tag bordered={false} className={getProductStatusClass(status)}>
           {status}
@@ -88,6 +126,9 @@ export function ProductsPage() {
       key: 'skuCount',
       width: 100,
       align: 'right',
+      sorter: true,
+      sortOrder: sortField === 'skuCount' ? sortOrder : undefined,
+      showSorterTooltip: false,
       render: (_value, record) => record.skus.length,
     },
     {
@@ -96,28 +137,38 @@ export function ProductsPage() {
       key: 'totalStock',
       width: 140,
       align: 'right',
+      sorter: true,
+      sortOrder: sortField === 'totalStock' ? sortOrder : undefined,
+      showSorterTooltip: false,
     },
     {
       title: renderHeaderTitle('Price Range'),
-      key: 'priceRange',
+      key: 'minPrice',
       width: 180,
       align: 'right',
+      sorter: true,
+      sortOrder: sortField === 'minPrice' ? sortOrder : undefined,
+      showSorterTooltip: false,
       render: (_value, record) => (
         <span className="font-medium text-gray-800 dark:text-white/90">
           {formatPriceRange(record.minPrice, record.maxPrice)}
         </span>
       ),
     },
-  ];
+  ],
+  [sortField, sortOrder]
+  );
 
   return (
-    <div className="space-y-6">
+    <div className="flex min-h-0 flex-1 flex-col gap-6">
       <PageBreadcrumb pageTitle="Products" />
 
       <Card
         title="Products"
         description="Track your store's progress to boost your sales."
-        headerClassName="items-center pb-4"
+        className="flex min-h-0 flex-1 flex-col"
+        headerClassName="shrink-0 items-center pb-4"
+        bodyClassName="flex min-h-0 flex-1 flex-col overflow-hidden"
         disableBodyPadding
         actions={
           <div className="flex items-center gap-2">
@@ -142,7 +193,7 @@ export function ProductsPage() {
         footer={
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-body dark:text-bodydark2">
-              Showing {showingFrom}-{showingTo} of {filteredProducts.length}
+              Showing {showingFrom}-{showingTo} of {sortedProducts.length}
             </p>
             <div className="flex items-center gap-2">
               <Select<number>
@@ -195,7 +246,7 @@ export function ProductsPage() {
           </div>
         }
       >
-        <div className="flex flex-col gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-800 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex shrink-0 flex-col gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-800 sm:flex-row sm:items-center sm:justify-between">
           <div className="w-full sm:w-64">
             <Input
               allowClear
@@ -226,9 +277,13 @@ export function ProductsPage() {
             ]}
           />
         </div>
-        <Table<ProductRow>
+        <div className="min-h-0 flex-1 overflow-auto">
+          <Table<ProductRow>
+          tableLayout="fixed"
           columns={columns}
           dataSource={paginatedProducts}
+          onChange={handleTableChange}
+          sortDirections={['ascend', 'descend']}
           pagination={false}
           size="middle"
           rowClassName={() => 'cursor-pointer'}
@@ -253,8 +308,9 @@ export function ProductsPage() {
               ),
             expandedRowRender: (record) => (
               <Table<SKU & { key: number }>
+                tableLayout="fixed"
                 className="[&_.ant-table-tbody>tr>td.ant-table-cell:nth-child(2)]:!pl-8"
-                size="small"
+                size="middle"
                 pagination={false}
                 showHeader={false}
                 rowClassName={() => 'bg-gray-50 dark:bg-white/[0.02]'}
@@ -264,31 +320,26 @@ export function ProductsPage() {
                   {
                     title: '',
                     key: 'spacer',
-                    width: 44,
+                    width: 20,
                     render: () => null,
                   },
                   {
-                    title: 'SKU',
-                    dataIndex: 'id',
-                    key: 'id',
-                    width: 140,
-                    render: (id: number) => (
-                      <span className="text-body dark:text-bodydark2">SKU #{id}</span>
-                    ),
-                  },
-                  {
-                    title: 'Attributes',
-                    key: 'attributes',
+                    title: 'Product',
+                    key: 'product',
+                    width: 200,
                     render: (_value, sku) => (
-                      <span className="text-body dark:text-bodydark2">
-                        {formatKeyValuePairs(sku.attributes)}
+                      <span className="whitespace-nowrap text-body dark:text-bodydark2">
+                        {sku.id}
+                        {sku.attributes && Object.keys(sku.attributes).length > 0
+                          ? ` — ${formatKeyValuePairs(sku.attributes)}`
+                          : ''}
                       </span>
                     ),
                   },
                   {
-                    title: 'Stock',
+                    title: 'Status',
                     key: 'stockTag',
-                    width: 140,
+                    width: 150,
                     render: (_value, sku) => (
                       <Tag bordered={false} className={getStockStatusClass(sku.stock)}>
                         {sku.stock === 0 ? 'Out of Stock' : sku.stock < 10 ? 'Low Stock' : 'In Stock'}
@@ -296,16 +347,23 @@ export function ProductsPage() {
                     ),
                   },
                   {
-                    title: 'Qty',
+                    title: 'SKUs',
+                    key: 'skusPlaceholder',
+                    width: 100,
+                    align: 'right',
+                    render: () => null,
+                  },
+                  {
+                    title: 'Total Stock',
                     dataIndex: 'stock',
                     key: 'stock',
-                    width: 90,
+                    width: 140,
                     align: 'right',
                   },
                   {
-                    title: 'Price',
+                    title: 'Price Range',
                     key: 'price',
-                    width: 140,
+                    width: 180,
                     align: 'right',
                     render: (_value, sku) => (
                       <span className="font-medium text-gray-800 dark:text-white/90">
@@ -318,6 +376,7 @@ export function ProductsPage() {
             ),
           }}
         />
+        </div>
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Problem**: Products sub-table columns do not align with the main table; main table has no sorting; main content does not fill remaining viewport height.
- **Approach**: Match parent and sub-table column widths with `tableLayout: fixed`; add client-side sorting; use flex layout so main and Outlet fill remaining height.

## Changes
- DefaultLayout: add `flex-1 min-h-0` to main; use flex on inner div and Outlet wrapper to fill height
- Products: sub-table columns aligned with parent; SKU shown as `101 — Color: Black`; add sort for Product, Status, SKUs, Total Stock, Price Range; adjust spacer width

## Scope
- [x] page
- [ ] layout
- [ ] ui
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [ ] devops

## Screenshots / Recording (if UI changes)
- Sub-table aligned; sorting enabled; content fills viewport
<img width="1579" height="285" alt="Screenshot 2026-02-16 at 8 45 33 am" src="https://github.com/user-attachments/assets/8a79581b-d787-45b8-94d0-b961e1bf534b" />

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] Manual check:
  - [x] Works on Chrome
  - [ ] Works on Safari (if applicable)

## Checklist
- [x] I kept the PR small and focused (or explained why not)
- [ ] I updated docs/README if needed
- [ ] I added/updated tests if needed
- [x] No secrets or credentials are included

## Related
- Fixes #30 
- Follow-ups:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Products list now supports sorting by name, status, SKU count, total stock, and price range.

* **Style**
  * Improved layout structure for better content scaling and responsiveness across different viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->