### PR TITLE
Chore/outfit default font

### DIFF
--- a/apps/web/src/styles/salesops.css
+++ b/apps/web/src/styles/salesops.css
@@ -2,7 +2,7 @@
 
 @layer base {
   body {
-    @apply font-normal text-base text-body bg-gray-50 relative z-1;
+    @apply font-sans font-normal text-base text-body bg-gray-50 relative z-1;
   }
 
   .ant-app {

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -10,6 +10,9 @@ export default {
   darkMode: 'class',
   theme: {
     fontFamily: {
+      sans: ['Outfit', 'sans-serif'],
+      serif: ['Outfit', 'sans-serif'],
+      mono: ['Outfit', 'sans-serif'],
       outfit: ['Outfit', 'sans-serif'],
     },
     screens: {


### PR DESCRIPTION
## Summary
- **What problem does this PR solve?** Unify and improve the default sans-serif font across the app for a more consistent, readable UI.
- **What approach did you take?** Set Outfit as the default sans font in Tailwind config and applied it globally via `salesops.css`.

## Changes
- Set Outfit as the default sans font in `tailwind.config.js` and `apps/web/src/styles/salesops.css`

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [x] theme
- [ ] devops

## Related
- Fixes #48 
- Follow-ups:

Branch: chore/outfit-default-font

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Configured font family settings to standardize sans-serif typography throughout the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->