### PR TITLE
chore(theme): set outfit as default sans font

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -11,8 +11,6 @@ export default {
   theme: {
     fontFamily: {
       sans: ['Outfit', 'sans-serif'],
-      serif: ['Outfit', 'sans-serif'],
-      mono: ['Outfit', 'sans-serif'],
       outfit: ['Outfit', 'sans-serif'],
     },
     screens: {


### PR DESCRIPTION
##Summary

- **What problem does this PR solve?** The app did not use Outfit as the default sans font, so typography was inconsistent with the intended design.
- **What approach did you take?** Set Outfit as the default sans font in Tailwind and applied font-sans on the body so the whole app uses Outfit by default.

##Changes

- Set Outfit as the default sans font in tailwind.config.js (theme.fontFamily.sans).
- Apply font-sans to body in salesops.css so the default sans stack is used globally.
- Add Cursor commands and rules (branch naming, commit message, PR/issue markdown generation, Cloudinary standard).

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [x] theme
- [ ] devops

## Related
- Fixes #50 
- Follow-ups:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed serif and mono font configuration options from the application styling setup. The application now utilizes only sans-serif fonts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->