### PR TITLE
feat(auth): add clerk auth with login flow and auth guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ apps/web/public/example/
 # API env and local DB
 .env
 apps/api/.env
+apps/web/.env.local
 apps/api/generated/
 apps/api/prisma/**/*.db
 apps/api/prisma/**/*.db-journal

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
+    "@clerk/clerk-react": "^5.61.1",
     "@reduxjs/toolkit": "^2.5.0",
     "@salesops/shared": "0.0.0",
     "@tanstack/react-query": "^5.66.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,19 @@
+import { Outlet, useRouterState } from '@tanstack/react-router';
+import { AuthGuard } from '@/components/AuthGuard';
 import { DefaultLayout } from '@/layout/DefaultLayout';
 
+const AUTH_PATHS = ['/login', '/auth/signin', '/auth/signup'];
+
 export default function App() {
-  return <DefaultLayout />;
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isAuthPage = AUTH_PATHS.includes(pathname);
+
+  if (isAuthPage) {
+    return <Outlet />;
+  }
+  return (
+    <AuthGuard>
+      <DefaultLayout />
+    </AuthGuard>
+  );
 }

--- a/apps/web/src/components/AuthGuard.tsx
+++ b/apps/web/src/components/AuthGuard.tsx
@@ -1,0 +1,39 @@
+import { useAuth } from '@clerk/clerk-react';
+import { useEffect } from 'react';
+import { useNavigate, useRouterState } from '@tanstack/react-router';
+
+const LOGIN_PATH = '/login';
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Protects backend routes: redirects to /login when user is not signed in.
+ */
+export function AuthGuard({ children }: AuthGuardProps) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      navigate({ to: LOGIN_PATH, search: { redirect: pathname } });
+    }
+  }, [isLoaded, isSignedIn, navigate, pathname]);
+
+  if (!isLoaded) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/AuthPageShell.tsx
+++ b/apps/web/src/components/AuthPageShell.tsx
@@ -1,0 +1,36 @@
+export function AuthPageShell({
+  children,
+  footer,
+}: {
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-brand-25 via-gray-50 to-brand-50/50 dark:from-gray-900 dark:via-gray-900 dark:to-brand-950/30">
+      {/* Decorative blobs */}
+      <div
+        className="pointer-events-none absolute -left-24 -top-24 h-72 w-72 rounded-full bg-brand-200/40 blur-3xl dark:bg-brand-600/20"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -bottom-24 -right-24 h-80 w-80 rounded-full bg-brand-300/30 blur-3xl dark:bg-brand-700/15"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute right-1/3 top-1/4 h-40 w-40 rounded-full bg-secondary/20 blur-2xl dark:bg-secondary/10"
+        aria-hidden
+      />
+
+      <div className="relative z-10 w-full max-w-md space-y-6 px-4 py-8">
+        <div className="flex flex-col gap-6">
+          {children}
+        </div>
+        {footer && (
+          <p className="text-center text-sm text-body dark:text-bodydark">
+            {footer}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Header/index.tsx
+++ b/apps/web/src/components/Header/index.tsx
@@ -149,7 +149,6 @@ export default function Header() {
             <div className="flex items-center gap-2">
               <SignedIn>
                 <UserButton
-                  afterSignOutUrl="/login"
                   appearance={{
                     elements: {
                       userButtonAvatarBox: 'h-10 w-10',

--- a/apps/web/src/components/Header/index.tsx
+++ b/apps/web/src/components/Header/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
+import { SignedIn, SignedOut, UserButton } from '@clerk/clerk-react';
 import { useSidebar } from '@/context/SidebarContext';
 import DropdownMessage from './DropdownMessage';
 import DropdownNotification from './DropdownNotification';
-import DropdownUser from './DropdownUser';
 import DarkModeSwitcher from './DarkModeSwitcher';
 
 export default function Header() {
@@ -31,7 +31,7 @@ export default function Header() {
   }, []);
 
   return (
-    <header className="sticky top-0 z-99999 flex w-full border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 lg:border-b">
+    <header className="sticky top-0 z-50 flex w-full border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 lg:border-b">
       <div className="flex flex-col grow items-center justify-between lg:flex-row lg:px-6">
         <div className="flex w-full items-center justify-between gap-2 border-b border-gray-200 px-3 py-3 dark:border-gray-800 sm:gap-4 lg:justify-normal lg:border-b-0 lg:px-0 lg:py-4">
           <button
@@ -146,8 +146,27 @@ export default function Header() {
             <DarkModeSwitcher />
             <DropdownNotification />
             <DropdownMessage />
+            <div className="flex items-center gap-2">
+              <SignedIn>
+                <UserButton
+                  afterSignOutUrl="/login"
+                  appearance={{
+                    elements: {
+                      userButtonAvatarBox: 'h-10 w-10',
+                    },
+                  }}
+                />
+              </SignedIn>
+              <SignedOut>
+                <Link
+                  to="/login"
+                  className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-800 dark:bg-white/[0.03] dark:text-gray-300 dark:hover:bg-white/10"
+                >
+                  Log in
+                </Link>
+              </SignedOut>
+            </div>
           </div>
-          <DropdownUser />
         </div>
       </div>
     </header>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,3 +4,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Center Clerk sign-in/sign-out modal in viewport */
+[data-clerk-modal-scope] {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}

--- a/apps/web/src/layout/DefaultLayout.tsx
+++ b/apps/web/src/layout/DefaultLayout.tsx
@@ -21,7 +21,7 @@ function LayoutContent() {
         >
           <div
             id="header-dropdown-root"
-            className="pointer-events-none fixed inset-0 z-[100000]"
+            className="pointer-events-none fixed inset-0 z-[100]"
             aria-hidden
           />
           <Header />

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import '@ant-design/v5-patch-for-react-19';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
 import { Provider } from 'react-redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
@@ -10,11 +11,17 @@ import './index.css';
 import { store } from '@/store';
 import { router } from '@/router';
 
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+if (!PUBLISHABLE_KEY) {
+  throw new Error('Missing Clerk Publishable Key');
+}
+
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <Provider store={store}>
+    <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/login">
+      <Provider store={store}>
       <QueryClientProvider client={queryClient}>
         <ConfigProvider
           theme={{
@@ -37,5 +44,6 @@ createRoot(document.getElementById('root') as HTMLElement).render(
         </ConfigProvider>
       </QueryClientProvider>
     </Provider>
+    </ClerkProvider>
   </StrictMode>,
 );

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -17,6 +17,7 @@ import { ButtonsPage } from '@/views/ButtonsPage';
 import { FormElementsPage } from '@/views/FormElementsPage';
 import { FormLayoutPage } from '@/views/FormLayoutPage';
 import { SignInPage } from '@/views/SignInPage';
+import { LoginPage } from '@/views/LoginPage';
 import { SignUpPage } from '@/views/SignUpPage';
 import { ProductsPage } from '@/views/Products';
 import { ProductDetailPage } from '@/views/ProductDetailPage';
@@ -143,6 +144,12 @@ const signInRoute = createRoute({
   component: SignInPage,
 });
 
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: LoginPage,
+});
+
 const signUpRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/auth/signup',
@@ -250,6 +257,7 @@ const routeTree = rootRoute.addChildren([
   formElementsRoute,
   formLayoutRoute,
   signInRoute,
+  loginRoute,
   signUpRoute,
   ecommerceRoute.addChildren([
     productsRoute,

--- a/apps/web/src/views/LoginPage.tsx
+++ b/apps/web/src/views/LoginPage.tsx
@@ -1,18 +1,33 @@
-import { SignUp } from '@clerk/clerk-react';
+import { SignIn, useAuth } from '@clerk/clerk-react';
 import { Link } from '@tanstack/react-router';
 import { AuthPageShell } from '@/components/AuthPageShell';
 
-export function SignUpPage() {
+const LoadingState = () => (
+  <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-brand-25 via-gray-50 to-brand-50/50 dark:from-gray-900 dark:via-gray-900 dark:to-brand-950/30">
+    <div className="flex flex-col items-center gap-4">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+      <p className="text-sm text-body dark:text-bodydark">Loading...</p>
+    </div>
+  </div>
+);
+
+export function LoginPage() {
+  const { isLoaded, isSignedIn } = useAuth();
+
+  if (!isLoaded || isSignedIn) {
+    return <LoadingState />;
+  }
+
   return (
     <AuthPageShell
       footer={
         <>
-          Already have an account?{' '}
+          Don&apos;t have an account?{' '}
           <Link
-            to="/login"
+            to="/auth/signup"
             className="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400"
           >
-            Sign in
+            Sign up
           </Link>
         </>
       }
@@ -24,7 +39,7 @@ export function SignUpPage() {
         <img src="/logo.svg" alt="SalesOps" className="h-10" />
       </Link>
       <div className="flex flex-col items-center justify-center">
-        <SignUp
+        <SignIn
           appearance={{
             elements: {
               rootBox: 'w-full',
@@ -32,7 +47,7 @@ export function SignUpPage() {
               cardBox: 'w-full',
             },
           }}
-          signInUrl="/login"
+          signUpUrl="/auth/signup"
           forceRedirectUrl="/dashboard/ecommerce"
           fallbackRedirectUrl="/dashboard/ecommerce"
         />

--- a/apps/web/src/views/LoginPage.tsx
+++ b/apps/web/src/views/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { SignIn, useAuth } from '@clerk/clerk-react';
-import { Link } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { AuthPageShell } from '@/components/AuthPageShell';
 
 const LoadingState = () => (
@@ -11,8 +12,17 @@ const LoadingState = () => (
   </div>
 );
 
+const AUTHENTICATED_REDIRECT = '/dashboard/ecommerce';
+
 export function LoginPage() {
   const { isLoaded, isSignedIn } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLoaded && isSignedIn) {
+      navigate({ to: AUTHENTICATED_REDIRECT });
+    }
+  }, [isLoaded, isSignedIn, navigate]);
 
   if (!isLoaded || isSignedIn) {
     return <LoadingState />;

--- a/apps/web/src/views/SignInPage.tsx
+++ b/apps/web/src/views/SignInPage.tsx
@@ -1,9 +1,67 @@
-import { SignIn } from '@clerk/clerk-react';
+import { SignIn, useAuth } from '@clerk/clerk-react';
+import { useEffect } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { AuthPageShell } from '@/components/AuthPageShell';
+
+const LoadingState = () => (
+  <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-brand-25 via-gray-50 to-brand-50/50 dark:from-gray-900 dark:via-gray-900 dark:to-brand-950/30">
+    <div className="flex flex-col items-center gap-4">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+      <p className="text-sm text-body dark:text-bodydark">Loading...</p>
+    </div>
+  </div>
+);
+
+const AUTHENTICATED_REDIRECT = '/dashboard/ecommerce';
 
 export function SignInPage() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isLoaded && isSignedIn) {
+      navigate({ to: AUTHENTICATED_REDIRECT });
+    }
+  }, [isLoaded, isSignedIn, navigate]);
+
+  if (!isLoaded || isSignedIn) {
+    return <LoadingState />;
+  }
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
-      <SignIn />
-    </div>
+    <AuthPageShell
+      footer={
+        <>
+          Don&apos;t have an account?{' '}
+          <Link
+            to="/auth/signup"
+            className="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400"
+          >
+            Sign up
+          </Link>
+        </>
+      }
+    >
+      <Link
+        to="/"
+        className="flex justify-center transition-opacity hover:opacity-90"
+      >
+        <img src="/logo.svg" alt="SalesOps" className="h-10" />
+      </Link>
+      <div className="flex flex-col items-center justify-center">
+        <SignIn
+          appearance={{
+            elements: {
+              rootBox: 'w-full',
+              card: 'w-full shadow-none',
+              cardBox: 'w-full',
+            },
+          }}
+          signUpUrl="/auth/signup"
+          forceRedirectUrl="/dashboard/ecommerce"
+          fallbackRedirectUrl="/dashboard/ecommerce"
+        />
+      </div>
+    </AuthPageShell>
   );
 }

--- a/apps/web/src/views/SignInPage.tsx
+++ b/apps/web/src/views/SignInPage.tsx
@@ -1,23 +1,9 @@
-import { Button, Card, Form, Input } from 'antd';
+import { SignIn } from '@clerk/clerk-react';
 
 export function SignInPage() {
   return (
-    <div className="mx-auto max-w-xl space-y-6">
-      <h1 className="text-title-md2 font-semibold text-black dark:text-white">Sign In</h1>
-      <Card className="shadow-1">
-        <Form layout="vertical">
-          <Form.Item label="Email" name="email">
-            <Input placeholder="you@example.com" />
-          </Form.Item>
-          <Form.Item label="Password" name="password">
-            <Input.Password placeholder="••••••••" />
-          </Form.Item>
-          <Button type="primary" htmlType="submit">
-            Sign In
-          </Button>
-        </Form>
-      </Card>
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
+      <SignIn />
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- **What problem does this PR solve?** The web app had no authentication; routes were open and there was no way to sign in, sign up, or sign out.
- **What approach did you take?** Integrated Clerk via `@clerk/clerk-react`, wrapped the app with `ClerkProvider`, and added an `AuthGuard` so only `/login`, `/auth/signin`, and `/auth/signup` are public. Auth pages use Clerk’s `<SignIn />` and `<SignUp />`; the header shows sign-in state with `UserButton` and a "Log in" link.

## Changes
- Add `@clerk/clerk-react` and wrap the app with `ClerkProvider` (publishable key from `VITE_CLERK_PUBLISHABLE_KEY`).
- Add `AuthGuard` to redirect unauthenticated users to `/login` for protected routes.
- Add `/login` route, `LoginPage`, and `AuthPageShell` for auth screens.
- Refactor `SignInPage` and `SignUpPage` to use Clerk’s `<SignIn />` and `<SignUp />`.
- Update Header with Clerk `SignedIn` / `SignedOut`, `UserButton`, and "Log in" link; remove `DropdownUser`.
- Add CSS in `index.css` to center Clerk’s sign-in/sign-up modal.
- Add `apps/web/.env.local` to `.gitignore`.
- Adjust z-index in Header and DefaultLayout for modal/dropdown stacking.

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [x] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [ ] devops

## Screenshots / Recording (if UI changes)
- After:
  <img width="3402" height="1716" alt="image" src="https://github.com/user-attachments/assets/eaf0cd54-bb08-426e-9b34-10058a46d4c7" />
  <img width="3436" height="1486" alt="image" src="https://github.com/user-attachments/assets/7aaba8d8-28d9-458f-97c0-febb77c0eb5b" />

## Related
- Fixes #52 
- Follow-ups:
- Branch: `feature/clerk-auth`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive authentication system with sign-in and sign-up flows and a new login page
  * Route protection for authenticated areas and a centered auth page layout
  * User account button appears in header when signed in; login link shown when signed out

* **Chores**
  * Added authentication dependency and wrapped app with an authentication provider
  * Ignored local env file and adjusted modal centering and header z-index styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->