### PR TITLE
chore(devops): migrate cursor rules and commands to agent skills

### DIFF
--- a/.cursor/skills/branch-and-commit/SKILL.md
+++ b/.cursor/skills/branch-and-commit/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: branch-and-commit
+description: Branch from develop and commit all changes
+disable-model-invocation: true
+---
+
 # Branch from develop and commit all changes
 
 When I run this command, do the following in order.

--- a/.cursor/skills/branch-naming/SKILL.md
+++ b/.cursor/skills/branch-naming/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: branch-naming
 description: Branch naming conventions when creating new branches from develop; use when creating or suggesting branch names
 ---
 

--- a/.cursor/skills/commit-changes/SKILL.md
+++ b/.cursor/skills/commit-changes/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: commit-changes
+description: Commit changes (multiple commits by relevance)
+disable-model-invocation: true
+---
+
 # Commit changes (multiple commits by relevance)
 
 When I run this command, do the following in order.

--- a/.cursor/skills/commit-message/SKILL.md
+++ b/.cursor/skills/commit-message/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: commit-message
 description: Commit message format and conventions enforced by commitlint; use when writing or suggesting git commit messages
 ---
 

--- a/.cursor/skills/generate-cursor-rules/SKILL.md
+++ b/.cursor/skills/generate-cursor-rules/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: generate-cursor-rules
+description: Cursor Rules Instructions
+disable-model-invocation: true
+---
+
 # Cursor Rules Instructions
 
 To create or edit a rule:

--- a/.cursor/skills/generate-issue-markdown/SKILL.md
+++ b/.cursor/skills/generate-issue-markdown/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: generate-issue-markdown
+description: Generate English issue markdown
+disable-model-invocation: true
+---
+
 # Generate English issue markdown
 
 When I run this command, generate a **single, copyable English issue** in Markdown format that I can paste into GitHub, GitLab, Jira, or similar. Output it inside a **fenced code block** (language: `markdown`) so I can **click the copy button** on the block to copy in one go. The issue must be **based on the current branch and all commits on that branch**.

--- a/.cursor/skills/generate-pr-markdown/SKILL.md
+++ b/.cursor/skills/generate-pr-markdown/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: generate-pr-markdown
+description: Generate PR markdown from current branch commits
+disable-model-invocation: true
+---
+
 # Generate PR markdown from current branch commits
 
 When I run this command, generate a **single, copyable PR description** in Markdown that follows the repo’s pull request template. The content must be **based on the current branch and all commits on that branch**.


### PR DESCRIPTION
## Summary
- Consolidates Cursor “slash command” workflows and two unscoped project rules into **Agent Skills** under `.cursor/skills/**`, so the same guidance is available in the Skills model without relying on `.cursor/commands` / those `.mdc` files for that subset.
- Follows Cursor’s SKILL format (`name`, `description`, plus `disable-model-invocation` for migrated commands); **glob-scoped rules stay in `.cursor/rules`** unchanged.

## Changes
- Move former commands to skills: `commit-changes`, `branch-and-commit`, `generate-cursor-rules`, `generate-pr-markdown`, `generate-issue-markdown`.
- Move former unscoped rules to skills: `commit-message`, `branch-naming`.
- Remove the old `.cursor/commands/*.md` and `.cursor/rules/{commit-message,branch-naming}.mdc` paths in favor of the new `SKILL.md` locations.

## Scope
Select one (aligns with `commitlint.config.cjs` scopes):
- [ ] ui
- [ ] layout
- [ ] page
- [ ] component
- [ ] hook
- [ ] api
- [ ] state
- [ ] router
- [ ] auth
- [ ] permission
- [ ] i18n
- [ ] theme
- [x] devops

## Screenshots / Recording (if UI changes)
- Before:
- After:

## Test plan
- [ ] `npm run lint`
- [ ] `npm test` (if applicable)
- [ ] Manual check:
  - [ ] Works on Chrome
  - [ ] Works on Safari (if applicable)

## Checklist
- [ ] I kept the PR small and focused (or explained why not)
- [ ] I updated docs/README if needed
- [ ] I added/updated tests if needed
- [ ] No secrets or credentials are included

## Related
- Fixes #68 
- Follow-ups:

Branch: chore/migrate-cursor-rules-to-skills